### PR TITLE
mlr3learners dependencies missing

### DIFF
--- a/mlr3full/Dockerfile
+++ b/mlr3full/Dockerfile
@@ -25,6 +25,7 @@ RUN install2.r --error --skipinstalled --ncpus ${NCPUS} --deps TRUE \
     mlr3hyperband \
     mlr3oml \
     mlr3verse \
+    mlr3learners \
     remotes \
     && installGithub.r mlr-org/mlr3proba \
     && installGithub.r --deps TRUE mlr-org/mlr3extralearners \

--- a/mlr3full/Dockerfile
+++ b/mlr3full/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     liblzma-dev \
     libpcre2-dev \
     libxml2-dev \
+    libglpk40 \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
mlr3learners dependencies (suggests) are missing which means that you cannot use any of the learners from the package. I add mlr3learners installation explicitly.